### PR TITLE
use only tar to extract and copy phantomjs bin

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+phantomjs_version: "1.9.7"
+phantomjs_url: "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2"

--- a/filter_plugins/customs.py
+++ b/filter_plugins/customs.py
@@ -1,8 +1,0 @@
-class FilterModule(object):
-  def filters(self):
-    return {
-      'filename_without_extension': self.filename_without_extension
-    }
-
-  def filename_without_extension(self, path, extension):
-    return path[:-len(extension)]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Raphael Randschau"
   license: MIT
   min_ansible_version: 1.4
-  version: 0.1
+  version: 0.2
   platforms:
    - name: Ubuntu
      versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,8 @@
     force: true
   when: "not phantomjs.installed or phantomjs.version != '{{ phantomjs_version }}'"
 
-- shell: "cd /tmp && tar xvjf /tmp/phantomjs.tar.bz2"
-  when: "not phantomjs.installed or phantomjs.version != '{{ phantomjs_version }}'"
-
-- shell: cp -f /tmp/{{ phantomjs_url | basename | filename_without_extension('.tar.bz2') }}/bin/phantomjs /usr/local/bin/phantomjs
+# extract and copy in one step --strip-components=2 takes care that we don't copy the entire path just the bin file
+- shell: "cd /tmp && tar xvjf /tmp/phantomjs.tar.bz2 -C /usr/local/bin/ --overwrite --wildcards '**/bin/phantomjs' --strip-components=2"
   sudo: true
   when: "not phantomjs.installed or phantomjs.version != '{{ phantomjs_version }}'"
 


### PR DESCRIPTION
also added default for latest phantomjs release.

I experienced an error in the extraction script when trying to use the latest release from bitbucket, that is my fix :)
